### PR TITLE
Store WithValues in Zerolog.Context instead

### DIFF
--- a/example/example_test.go
+++ b/example/example_test.go
@@ -58,9 +58,9 @@ func ExampleNew() {
 	Helper(log, "thru a helper")
 
 	// Output:
-	// {"v":0,"module":"example","val1":1,"val2":{"k":1},"logger":"MyName","message":"hello"}
-	// {"v":1,"module":"example","logger":"MyName","message":"you should see this"}
-	// {"module":"example","trouble":true,"reasons":[0.1,0.11,3.14],"logger":"MyName","message":"uh oh"}
-	// {"error":"an error occurred","module":"example","code":-1,"logger":"MyName","message":"goodbye"}
-	// {"v":0,"module":"example","logger":"MyName","message":"thru a helper"}
+	// {"module":"example","v":0,"logger":"MyName","val1":1,"val2":{"k":1},"message":"hello"}
+	// {"module":"example","v":1,"logger":"MyName","message":"you should see this"}
+	// {"module":"example","logger":"MyName","trouble":true,"reasons":[0.1,0.11,3.14],"message":"uh oh"}
+	// {"module":"example","error":"an error occurred","logger":"MyName","code":-1,"message":"goodbye"}
+	// {"module":"example","v":0,"logger":"MyName","message":"thru a helper"}
 }

--- a/zerologr.go
+++ b/zerologr.go
@@ -38,10 +38,9 @@ type Logger = logr.Logger
 
 // LogSink implements logr.LogSink and logr.CallDepthLogSink.
 type LogSink struct {
-	l      *zerolog.Logger
-	name   string
-	values []interface{}
-	depth  int
+	l     *zerolog.Logger
+	name  string
+	depth int
 }
 
 // Underlier exposes access to the underlying logging implementation.  Since
@@ -100,21 +99,18 @@ func (ls *LogSink) msg(e *zerolog.Event, msg string, keysAndValues []interface{}
 	if e == nil {
 		return
 	}
-	if len(ls.values) > 0 {
-		e = e.Fields(ls.values)
-	}
-	e = e.Fields(keysAndValues)
 	if ls.name != "" {
 		e.Str(NameFieldName, ls.name)
 	}
+	e = e.Fields(keysAndValues)
 	e.CallerSkipFrame(int(ls.depth))
 	e.Msg(msg)
 }
 
 // WithValues returns a new LogSink with additional key/value pairs.
 func (ls LogSink) WithValues(keysAndValues ...interface{}) logr.LogSink {
-	n := len(ls.values)
-	ls.values = append(ls.values[:n:n], keysAndValues...)
+	l := ls.l.With().Fields(keysAndValues).Logger()
+	ls.l = &l
 	return &ls
 }
 


### PR DESCRIPTION
Only one-time cost of Fields() to convert interface slice to internal byte slice of Zerolog.Context.