### PR TITLE
Give options to choose level key

### DIFF
--- a/example/example_test.go
+++ b/example/example_test.go
@@ -58,6 +58,29 @@ func ExampleNew() {
 	Helper(log, "thru a helper")
 
 	// Output:
+	// {"module":"example","v":0,"logger":"MyName","val1":1,"val2":{"k":1},"message":"hello"}
+	// {"module":"example","v":1,"logger":"MyName","message":"you should see this"}
+	// {"module":"example","logger":"MyName","trouble":true,"reasons":[0.1,0.11,3.14],"message":"uh oh"}
+	// {"module":"example","error":"an error occurred","logger":"MyName","code":-1,"message":"goodbye"}
+	// {"module":"example","v":0,"logger":"MyName","message":"thru a helper"}
+}
+
+func ExampleUseZerologLevelFieldName() {
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	zl := zerolog.New(os.Stdout)
+	zerologr.UseZerologLevelFieldName = true
+	log := zerologr.New(&zl)
+	log = log.WithName("MyName")
+	log = log.WithValues("module", "example")
+
+	log.Info("hello", "val1", 1, "val2", map[string]int{"k": 1})
+	log.V(1).Info("you should see this")
+	log.V(1).V(1).Info("you should NOT see this")
+	log.Error(nil, "uh oh", "trouble", true, "reasons", []float64{0.1, 0.11, 3.14})
+	log.Error(E{"an error occurred"}, "goodbye", "code", -1)
+	Helper(log, "thru a helper")
+
+	// Output:
 	// {"level":"info","module":"example","v":0,"logger":"MyName","val1":1,"val2":{"k":1},"message":"hello"}
 	// {"level":"debug","module":"example","v":1,"logger":"MyName","message":"you should see this"}
 	// {"level":"error","module":"example","logger":"MyName","trouble":true,"reasons":[0.1,0.11,3.14],"message":"uh oh"}

--- a/example/example_test.go
+++ b/example/example_test.go
@@ -58,17 +58,18 @@ func ExampleNew() {
 	Helper(log, "thru a helper")
 
 	// Output:
-	// {"module":"example","v":0,"logger":"MyName","val1":1,"val2":{"k":1},"message":"hello"}
-	// {"module":"example","v":1,"logger":"MyName","message":"you should see this"}
-	// {"module":"example","logger":"MyName","trouble":true,"reasons":[0.1,0.11,3.14],"message":"uh oh"}
-	// {"module":"example","error":"an error occurred","logger":"MyName","code":-1,"message":"goodbye"}
-	// {"module":"example","v":0,"logger":"MyName","message":"thru a helper"}
+	// {"level":"info","module":"example","v":0,"logger":"MyName","val1":1,"val2":{"k":1},"message":"hello"}
+	// {"level":"debug","module":"example","v":1,"logger":"MyName","message":"you should see this"}
+	// {"level":"error","module":"example","logger":"MyName","trouble":true,"reasons":[0.1,0.11,3.14],"message":"uh oh"}
+	// {"level":"error","module":"example","error":"an error occurred","logger":"MyName","code":-1,"message":"goodbye"}
+	// {"level":"info","module":"example","v":0,"logger":"MyName","message":"thru a helper"}
 }
 
-func ExampleUseZerologLevelFieldName() {
+func ExampleDisableVLevelField() {
 	zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	zl := zerolog.New(os.Stdout)
-	zerologr.UseZerologLevelFieldName = true
+	zerologr.DisableVLevelField = true
+	zerologr.DisableZerologLevelField = false
 	log := zerologr.New(&zl)
 	log = log.WithName("MyName")
 	log = log.WithValues("module", "example")
@@ -81,9 +82,33 @@ func ExampleUseZerologLevelFieldName() {
 	Helper(log, "thru a helper")
 
 	// Output:
-	// {"level":"info","module":"example","v":0,"logger":"MyName","val1":1,"val2":{"k":1},"message":"hello"}
-	// {"level":"debug","module":"example","v":1,"logger":"MyName","message":"you should see this"}
+	// {"level":"info","module":"example","logger":"MyName","val1":1,"val2":{"k":1},"message":"hello"}
+	// {"level":"debug","module":"example","logger":"MyName","message":"you should see this"}
 	// {"level":"error","module":"example","logger":"MyName","trouble":true,"reasons":[0.1,0.11,3.14],"message":"uh oh"}
 	// {"level":"error","module":"example","error":"an error occurred","logger":"MyName","code":-1,"message":"goodbye"}
-	// {"level":"info","module":"example","v":0,"logger":"MyName","message":"thru a helper"}
+	// {"level":"info","module":"example","logger":"MyName","message":"thru a helper"}
+}
+
+func ExampleDisableZerologLevelField() {
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	zl := zerolog.New(os.Stdout)
+	zerologr.DisableVLevelField = false
+	zerologr.DisableZerologLevelField = true
+	log := zerologr.New(&zl)
+	log = log.WithName("MyName")
+	log = log.WithValues("module", "example")
+
+	log.Info("hello", "val1", 1, "val2", map[string]int{"k": 1})
+	log.V(1).Info("you should see this")
+	log.V(1).V(1).Info("you should NOT see this")
+	log.Error(nil, "uh oh", "trouble", true, "reasons", []float64{0.1, 0.11, 3.14})
+	log.Error(E{"an error occurred"}, "goodbye", "code", -1)
+	Helper(log, "thru a helper")
+
+	// Output:
+	// {"module":"example","v":0,"logger":"MyName","val1":1,"val2":{"k":1},"message":"hello"}
+	// {"module":"example","v":1,"logger":"MyName","message":"you should see this"}
+	// {"module":"example","logger":"MyName","trouble":true,"reasons":[0.1,0.11,3.14],"message":"uh oh"}
+	// {"module":"example","error":"an error occurred","logger":"MyName","code":-1,"message":"goodbye"}
+	// {"module":"example","v":0,"logger":"MyName","message":"thru a helper"}
 }

--- a/zerologr.go
+++ b/zerologr.go
@@ -105,15 +105,12 @@ func (ls *LogSink) Info(level int, msg string, keysAndValues ...interface{}) {
 		if level > 1-int(zerolog.GlobalLevel()) {
 			return
 		}
-		// Use Logr's "v" level field
-		l := ls.l.With().Int("v", level).Logger()
-		// Use Zerolog without a level
-		e = l.Log()
+		e = ls.l.Log()
 	} else {
 		e = ls.l.WithLevel(zerolog.Level(1 - level))
-		if !DisableVLevelField {
-			e.Int("v", level)
-		}
+	}
+	if !DisableVLevelField {
+		e.Int("v", level)
 	}
 	ls.msg(e, msg, keysAndValues)
 }
@@ -122,13 +119,11 @@ func (ls *LogSink) Info(level int, msg string, keysAndValues ...interface{}) {
 func (ls *LogSink) Error(err error, msg string, keysAndValues ...interface{}) {
 	var e *zerolog.Event
 	if DisableZerologLevelField {
-		// Use Logr's "v" level field
-		l := ls.l.With().Err(err).Logger()
-		// Use Zerolog without a level
-		e = l.Log()
+		e = ls.l.Log()
 	} else {
-		e = ls.l.Error().Err(err)
+		e = ls.l.Error()
 	}
+	e.Err(err)
 	ls.msg(e, msg, keysAndValues)
 }
 


### PR DESCRIPTION
https://github.com/go-logr/zerologr/issues/6#issuecomment-1012533184

This gives the user an option to retain Zerolog's level key, for example if they have already configured Zerolog elsewhere in their application and want Logr to output in the same format/options, or disable it and use the `v` level key.

If options are not set, no changes are made to the current API and both Zerolog's level key and the `v` level key are printed.