### PR TITLE
feat: remove the correspondence between v-levels and zerolog levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ import (
 
 func main() {
     zerolog.TimeFieldFormat = zerolog.TimeFormatUnixMs
+    zerologr.Verbosity = 2
     zerologr.NameFieldName = "logger"
     zerologr.NameSeparator = "/"
 
@@ -32,10 +33,14 @@ func main() {
 
 ## Implementation Details
 
-For the most part, concepts in Zerolog correspond directly with those in logr.
+~~For the most part, concepts in Zerolog correspond directly with those in logr.~~
 
-Levels in logr correspond to custom debug levels in Zerolog. Any given level
-in logr is represents by `zerologLevel = 1 - logrLevel`.
+~~Levels in logr correspond to custom debug levels in Zerolog. Any given level
+in logr is represents by `zerologLevel = 1 - logrLevel`.~~
 
-For example `V(2)` is equivalent to Zerolog's `TraceLevel`, while `V(1)` is
-equivalent to Zerolog's `DebugLevel`.
+~~For example `V(2)` is equivalent to Zerolog's `TraceLevel`, while `V(1)` is
+equivalent to Zerolog's `DebugLevel`.~~
+
+Only `info` and `error` levels are supported. You should control the verbosity of info through V-levels.
+
+For example `V(2)` will output `{"level": "info", "v": 2}`.

--- a/example/example_test.go
+++ b/example/example_test.go
@@ -44,7 +44,7 @@ func helper2(log logr.Logger, msg string) {
 }
 
 func ExampleNew() {
-	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	zerologr.Verbosity = 1
 	zl := zerolog.New(os.Stdout)
 	log := zerologr.New(&zl)
 	log = log.WithName("MyName")
@@ -59,7 +59,7 @@ func ExampleNew() {
 
 	// Output:
 	// {"level":"info","module":"example","v":0,"logger":"MyName","val1":1,"val2":{"k":1},"message":"hello"}
-	// {"level":"debug","module":"example","v":1,"logger":"MyName","message":"you should see this"}
+	// {"level":"info","module":"example","v":1,"logger":"MyName","message":"you should see this"}
 	// {"level":"error","module":"example","logger":"MyName","trouble":true,"reasons":[0.1,0.11,3.14],"message":"uh oh"}
 	// {"level":"error","module":"example","error":"an error occurred","logger":"MyName","code":-1,"message":"goodbye"}
 	// {"level":"info","module":"example","v":0,"logger":"MyName","message":"thru a helper"}

--- a/zerologr.go
+++ b/zerologr.go
@@ -32,6 +32,8 @@ var (
 	NameFieldName = "logger"
 	// NameSeparator separates names for logr.WithName.
 	NameSeparator = "/"
+	// Verbosity is the V logging level
+	Verbosity uint = 0
 	// VerbosityFieldName is the field key for logr.Info verbosity. If set to "",
 	// its value is not emitted.
 	VerbosityFieldName = "v"
@@ -84,14 +86,12 @@ func (ls *LogSink) Init(ri logr.RuntimeInfo) {
 
 // Enabled tests whether this LogSink is enabled at the specified V-level.
 func (ls *LogSink) Enabled(level int) bool {
-	// Optimization: Info() will check level internally.
-	const traceLevel = 1 - int(zerolog.TraceLevel)
-	return level <= traceLevel
+	return Verbosity >= uint(level)
 }
 
 // Info logs a non-error message at specified V-level with the given key/value pairs as context.
 func (ls *LogSink) Info(level int, msg string, keysAndValues ...interface{}) {
-	e := ls.l.WithLevel(zerolog.Level(1 - level))
+	e := ls.l.Info()
 	if VerbosityFieldName != "" {
 		e.Int(VerbosityFieldName, level)
 	}


### PR DESCRIPTION
We can only use the v-levels of `0`, `1`, `2`, corresponding to `InfoLevel`, `DebugLevel` and `TraceLevel` of Zerolog.

It limits the finer level of V-level control.

This pr remove the correspondence between v-levels and zerolog levels, to more v-levels support. 