### PR TITLE
Fix Enabled detection

### DIFF
--- a/zerologr.go
+++ b/zerologr.go
@@ -27,6 +27,10 @@ import (
 	"github.com/rs/zerolog"
 )
 
+const (
+	defaultLevelDelta zerolog.Level = 1
+)
+
 var (
 	// NameFieldName is the field key for logr.WithName.
 	NameFieldName = "logger"
@@ -84,14 +88,13 @@ func (ls *LogSink) Init(ri logr.RuntimeInfo) {
 
 // Enabled tests whether this LogSink is enabled at the specified V-level.
 func (ls *LogSink) Enabled(level int) bool {
-	// Optimization: Info() will check level internally.
-	const traceLevel = 1 - int(zerolog.TraceLevel)
-	return level <= traceLevel
+	return ls.l.GetLevel() <= zerologLevel(level)
 }
 
 // Info logs a non-error message at specified V-level with the given key/value pairs as context.
 func (ls *LogSink) Info(level int, msg string, keysAndValues ...interface{}) {
-	e := ls.l.WithLevel(zerolog.Level(1 - level))
+	e := ls.l.WithLevel(zerologLevel(level))
+
 	if VerbosityFieldName != "" {
 		e.Int(VerbosityFieldName, level)
 	}
@@ -163,4 +166,14 @@ func DefaultRender(keysAndValues []interface{}) []interface{} {
 		}
 	}
 	return keysAndValues
+}
+
+func zerologLevel(level int) zerolog.Level {
+	lvl := defaultLevelDelta - zerolog.Level(level)
+
+	if lvl < zerolog.TraceLevel {
+		lvl = zerolog.TraceLevel
+	}
+
+	return lvl
 }


### PR DESCRIPTION
Unfortunately, the optimization in the LogSink#Enabled method breaks the intended use of that function, as it is exposed to the user by logr.Logger#Enabled.  Currently, it's hardcoded to return true for any value between 0 and 2.  However, if I'm bothering to call log.Enabled explicitly, it's for one reason: I want to check if logging is enabled prior to doing an expensive operation solely for the sake of logging, such as doing an http dump of a request, or a stack trace.

As the comment in the code notes, Info() will do that for me already.  So I never need to call Enabled but for one reason: I need to know for sure that the message will be output prior to doing that expensive operation.

This implementation breaks that, since Enabled doesn't check the actual verbosity level of the logger implementation.  If it is to be of any use whatsoever, the result of Enabled must match that of the underlying logsink implementation.  The only way to check that is to...well, check it.

Since there's more than one place that the zerolog.Level is compared to the int level, I added a helper function to convert consistently.  I also parameterized it slightly with a constant.  Although it doesn't do anything now, that levelDelta value could be configurable in the future.