### PR TITLE
Allow more verbose logs (option 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,40 @@ func main() {
 }
 ```
 
+## Increasing verbosity
+
+You can do something like the following in your setup code:
+
+```go
+    l := zerolog.Level(1 - 3)
+    zerolog.SetGlobalLevel(l)
+    zl := zerolog.New(os.Stdout).Level(l)
+    log := zerologr.New(&zl)
+    log.V(3).Info("you should see this")
+    log.V(4).Info("you should NOT see this")
+```
+
+Zerolog's levels get more verbose as the number gets smaller, and more important
+as the number gets larger.
+
+The `1 - 3` in the above snippet means that `log.V(3).Info()` calls will be
+active. `1 - 4` would enable `log.V(4).Info()`, etc.  Note that Zerolog's levels
+are `int8` which means the most verbose level you can give it is `1 - 129`
+(-128). The Zerologr implementation will cap `V()` levels greater than 129 to
+129, so setting the Zerolog level to -128 really means "activate all logs".
+
 ## Implementation Details
 
 For the most part, concepts in Zerolog correspond directly with those in logr.
 
-Levels in logr correspond to custom debug levels in Zerolog. Any given level
-in logr is represents by `zerologLevel = 1 - logrLevel`.
+Zerolog uses semantically named levels for logging (`TraceLevel`, `DebugLevel`,
+`InfoLevel`, `WarningLevel`, ...). Logr uses arbitrary numeric levels.
 
-For example `V(2)` is equivalent to Zerolog's `TraceLevel`, while `V(1)` is
-equivalent to Zerolog's `DebugLevel`.
+Levels in logr correspond to levels in Zerolog. Any given level in logr is
+represents by `zerologLevel = 1 - logrLevel`.
+
+For example logr's `V(0)` is Zerolog's `InfoLevel` (which is numerically 1),
+`V(1)` is Zerolog's `DebugLevel` (which is numerically 0), and `V(2)` is
+Zerolog's `TraceLevel` (which is numerically -1). Zerolog does not have named
+levels that are more verbose than `TraceLevel`, and instead handles them
+numerically where `V(3)` is equivalent to Zerolog handling it as `-2`.

--- a/zerologr.go
+++ b/zerologr.go
@@ -85,8 +85,8 @@ func (ls *LogSink) Init(ri logr.RuntimeInfo) {
 // Enabled tests whether this LogSink is enabled at the specified V-level.
 func (ls *LogSink) Enabled(level int) bool {
 	// Optimization: Info() will check level internally.
-	const traceLevel = 1 - int(zerolog.TraceLevel)
-	return level <= traceLevel
+	zLevel := 1 - int(ls.l.GetLevel())
+	return level <= zLevel
 }
 
 // Info logs a non-error message at specified V-level with the given key/value pairs as context.

--- a/zerologr.go
+++ b/zerologr.go
@@ -86,6 +86,9 @@ func (ls *LogSink) Init(ri logr.RuntimeInfo) {
 func (ls *LogSink) Enabled(level int) bool {
 	// Optimization: Info() will check level internally.
 	zLevel := 1 - int(ls.l.GetLevel())
+	if zLevel > 129 {
+		zLevel = 129
+	}
 	return level <= zLevel
 }
 


### PR DESCRIPTION
Closes https://github.com/go-logr/zerologr/issues/20.

It looks like @thockin made a [PR to Zerolog](https://github.com/rs/zerolog/pull/350/files) to allow arbitrary levels. I updated this library to allow these more verbose levels in 2 approaches.

This is similar to https://github.com/go-logr/zapr#increasing-verbosity.

---

I prefer the [other approach](https://github.com/go-logr/zerologr/pull/23), where the specified Zerolog level matches logr's V() levels numerically.

This approach requires users do quick math to figure out that setting Zerolog to `-3` will show `V(4)` logs. This also means the actual log line shows different numerical values:

```go
	l := zerolog.Level(-2)
	zerolog.SetGlobalLevel(l)
	zl := zerolog.New(os.Stdout).Level(l)
	log := zerologr.New(&zl)
	log.Info("Info you should see this")
	log.V(1).Info("v1 you should see this")
	log.V(2).Info("v2 you should see this")
	log.V(3).Info("v3 you should see this")
	log.V(4).Info("v4 you should NOT see this")
```

Yields output that actually reads confusing between `level` and `v`:

```json
{"level":"info","v":0,"message":"Info you should see this"}
{"level":"debug","v":1,"message":"v1 you should see this"}
{"level":"trace","v":2,"message":"v2 you should see this"}
{"level":"-2","v":3,"message":"v3 you should see this"}
```